### PR TITLE
Seminars events collection

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -24,6 +24,11 @@ url: "" # the base hostname & protocol for your site, e.g. http://example.com
 twitter_username: jekyllrb
 github_username:  jekyll
 
+future: true # required for collections with a date field, where future events are desired.
+collections:
+  events:
+    output: true
+
 # Build settings
 markdown: kramdown
 #theme: minima
@@ -43,3 +48,8 @@ defaults:
     values:
       layout: "post"
       permalink: "/blog/:slug"
+  - scope:
+      path: ""
+      type: "events"
+    values:
+      layout: "event"

--- a/_events/seminar-2017-05-30.md
+++ b/_events/seminar-2017-05-30.md
@@ -1,0 +1,18 @@
+---
+category: seminar
+date: 2017-05-30  
+published: true
+
+from: "13:00"
+to: "14:00"
+location: "Workroom 2 (G05), The Diamond"
+speaker: "Ania Brown"
+institute: "Research Software Engineer, Oxford e-Research Centre"
+title: "Towards achieving GPU-native adaptive mesh refinement"
+image: "/assets/seminar_files/img/2017_05_30_gpu_amr.jpg"
+slides_url: "/assets/seminar_files/slides/2017_05_30_gpu_amr_talk.pdf"
+
+---
+**Abstract**: Modern simulations model increasingly complex multiscale systems, and the need to capture details at multiple length scales can lead to large memory requirements. Adaptive mesh refinement (AMR) is a method for reducing memory cost by varying the accuracy in each region to match the physical characteristics of the simulation, at the cost of increased data structure complexity. This complexity is a particular problem on the GPU architecture, which is most naturally suited to regular data sets. I will describe some of the optimisation and software challenges that need to be considered when implementing AMR on GPUs, based on my experience working on a GPU-native framework for stencil calculations on a tree-based adaptively refined mesh as part of my Master degree. Topics covered will include achieving coalesced access with the AMR data structure, memory defragmentation after grid changes and load balancing using space-filling curves.
+
+**Bio**: Ania is a research software engineer at the Oxford e-Research Centre. Her research interests are a combination of performance optimisation for large scale scientific simulation and software development methodology to improve the quality of such codes. She received her Master degree from the Tokyo Institute of Technology in 2015.

--- a/_events/seminar-2017-08-08.md
+++ b/_events/seminar-2017-08-08.md
@@ -1,0 +1,16 @@
+---
+category: seminar
+date: 2017-08-08
+published: true
+
+from: "13:00"
+to: "14:00"
+location: "Workroom 3 (205), The Diamond"
+speaker: "Twin Karmakharm"
+institute: "Research Software Engineer, University of Sheffield"
+title: "Containers for High Performance Computing"
+
+image: "/assets/seminar_files/img/2017_08_29_gpu_containers.jpg"
+slides_url: 
+---
+**Abstract**: Containerization is a lightweight virtualisation technology where users can package workflows, software, libraries and data for running on various machines with minimal loss of performance. The technology can be used a way for scientists to deploy custom software on the HPC cluster and easily share reproducible software along with their data. The talk explores the concept of containers and existing container technologies suitable for the HPC. Particular focus is given for Singularity which has recently been introduced on the new Sheffield Advance Research Computer (ShARC) cluster.

--- a/_events/seminar-2017-09-09.md
+++ b/_events/seminar-2017-09-09.md
@@ -1,0 +1,18 @@
+---
+category: seminar
+date: 2017-09-09
+published: true
+
+from: "13:00"
+to: "14:00"
+location: "Workroom 3 (205), The Diamond"
+speaker: "Dr Thomas Nowotny"
+institute: "University of Sussex"
+title: "Opportunities and challenges for spiking neural networks on GPUs"
+image: "/assets/seminar_files/img/2017_09_27_thomas_nowotny.jpg"
+slides_url: "https://sussex.app.box.com/s/8i7dby89e6fj2t8lw447y68dkrsc1oo5"
+
+---
+**Abstract**: In the past 6 years, we have developed the GeNN (GPU enhanced neuronal networks) framework for GPU accelerated spiking neuronal network simulations. In essence, GeNN is based on a simple design of code generation that allows a large extent of flexibility for computational models while at the same time taking care of some of the GPU specific optimisation work in the background. In this talk I will present the main features of GeNN, its design principles and show benchmarks. I will then discuss limitations, both specific to GeNN and to numerical simulation work on GPUs more generally and present some further work, including the SpineML-GeNN and Brian2GeNN interfaces. GeNN is developed within the Green Brain [http://greenbrain.group.shef.ac.uk/](http://greenbrain.group.shef.ac.uk/) and Brains on Board [http://brainsonboard.co.uk/](http://brainsonboard.co.uk/) projects and is available under GPL v2 at Github [http://genn-team.github.io/genn/](http://genn-team.github.io/genn/).
+
+**Bio**: Thomas Nowotny received his PhD in theoretical physics in 2001 from the University of Leipzig and worked for five years at the University of California, San Diego. In 2007 he joined the University of Sussex, where he is now a Professor of Informatics and the Director for Research and Knowledge Exchange at the School of Engineering and Informatics. His research interests include olfaction in animals and machines, GPU accelerated scientific computing, hybrid brain-computer systems and bio-inspired machine learning.

--- a/_events/seminar-2017-11-28.md
+++ b/_events/seminar-2017-11-28.md
@@ -1,0 +1,27 @@
+---
+category: seminar
+date: 2017-11-28
+published: true
+
+from: "11:00"
+to: "12:00"
+location: "Lecture Theatre G02, Firth Court"
+speaker: "Dr Stephen McGough"
+institute: "Newcastle University"
+title: "PARALLEM: massively Parallel Landscape Evolution Modelling"
+
+image: "/assets/seminar_files/img/2017_11_28_parallem.jpg"
+slides_url: "/assets/seminar_files/slides/2017_11_28_gpu_parallem_talk.pdf"
+---
+**Abstract**: Landscape Evolution Modelling (LEM) is used to predict how landscapes evolve over the millennia due to weathering and erosion. LEM's normally operate on a regular grid of cells each representing the height of a point within a landscape. The process can be broken up into the following stages applied to each cell: determination of the flow direction of water out of that cell, summation of the volume of water flowing through the cell and computation of the erosion / deposition in the cell. This process is repeated at regular intervals - either an annual time-step (due to computation complexity) or once for each major storm-event - for periods of around one million years. 
+
+Within each year/rainstorm there is great potential for speedup when executing on a GPGPU - flow direction for most cells can be performed independently, flow accumulation can easily be performed in parallel. However, due to certain 'real world' landscape features this potential can easily be lost. Landscape features such as plateaus - where all cells in a region have the same height - or sinks - (sets of) cells which have no lower neighbour, meaning water cannot escape - prevent optimal speedup being achieved. Likewise, computing the volume of water passing through a cell is inherently sequential - the sum of water through a cell at the end of a river depends on knowing the volume of water passing through all points upstream.
+
+CUDA algorithms have been developed for computing the LEM processes: Flow direction can be computed independently for each cell; A parallel breadth-first algorithm can be used for routing water over a plateau to an outlet cell; A parallel technique for 'filling' sinks (making them into lakes) which performs much of its work through parallel pointer jumping is used. Flow accumulation can be performed using a developed 'correct' algorithm where each cell which has no incorrect flows entering it can be computed and marked correct. The process of erosion / deposition can then be performed in a similar manner to flow accumulation with the eroded material being passed around. 
+
+In this talk we will present parallel techniques for overcoming these problems, demonstrating between two and three orders of magnitude speedup over the best-in- class LEM software for landscapes between 0.1 and 56 million cells - far larger than the traditional 5 thousand cell simulations which have previously been performed. This has led to a need for a re-evaluation of the models used within the LEM community. Errors in LEM simulation results, which have been used over the last 30+ years, have been attributed to the very small simulation sizes. However, with our 46+ million cell simulations - a realistic scale - we are now able to determine that these errors are not due to scale but rather due to the equations themselves.
+
+We will present our approach moving forwards to overcome these limitations and present initial results of this work.
+
+
+**Bio**: Dr Stephen McGough is a Senior Lecturer in the School of Computing at Newcastle University, UK. He obtained his PhD in the area of Parallel simulation and has worked for many years in the areas of parallel computing and simulation. Holding posts at Imperial College London, UCL, Newcastle University and Durham University. This has led to over fifty publications in the area of parallel computing including receiving the NVIDIA best paper award at HiPC 2012. His research focuses on the use of novel computing technologies, such as GPGPU, to solve real-world challenges.

--- a/_events/seminar-2018-04-16.md
+++ b/_events/seminar-2018-04-16.md
@@ -1,0 +1,18 @@
+---
+category: seminar
+date: 2018-04-16
+published: true
+
+from: "15:30"
+to: "16:30"
+location: "Hicks building, Lecture Theatre 6"
+speaker: "David Hubber"
+institute: "Researcher at Ludwig-Maximilians-Universität Munich"
+title: "Structuring code efficiently"
+image:
+slides_url:
+
+---
+**Abstract**: David will discuss how to structure code efficiently. He will also discuss code module design, decoupling strategies and test-driven development. 
+
+**Bio**: David Hubber is an astrophysicist by training that has worked extensively on writing software such as GANDALF and SEREN to simulate star forming regions. He has been a researcher at the university of Cardiff, the university of Sheffield, and is currently a Postdoc researcher Ludwig-Maximilians-Universitat Munich.

--- a/_events/seminar-2018-04-30.md
+++ b/_events/seminar-2018-04-30.md
@@ -1,0 +1,23 @@
+---
+category: seminar
+date: 2018-04-30 
+published: true
+
+from: "15:00"
+to: "16:00"
+location: "Broad Lane Lecture Theater 11 (BROAD-LT11)"
+speaker: "Peter Heywood"
+institute: "University of Sheffield"
+title: "Accelerating Road Network Simulations using GPUs"
+
+image: /assets/seminar_files/img/2018_04_30_roadNetwork.jpg
+slides_url:
+---
+**Abstract**: Road network Simulations are a vital tool used in the planning and management of transport network infrastructure. Large-scale simulations are computationally expensive tasks, taking many-hours for a single simulation to complete using multi-core CPU architectures, hindering the use of large-scale simulations.
+
+Using Graphics Processing Units (GPUs) we demonstrate that both Macroscopic (top-down) simulations and Microscopic (bottom-up) simulations can be considerably accelerated using many-core architectures and novel fine-grained data-parallel algorithms.
+
+A multi-GPU version of the SATURN macroscopic road network simulation package has been developed, demonstrating assignment performance improvements of over 11x compared to a multi-socket CPU. A FLAME GPU based microscopic simulation demonstrates performance improvements of up to 65x using a single GPU compared to the commercial multi-core microsimulation tool Aimsun.
+
+
+**Bio**: Peter Heywood is a Research Software Engineer and PhD candidate at the University of Sheffield. His research is focussed on using Graphics Processing Units (GPUs) to improve the performance of complex systems simulations; including transport network simulation and biological cellular simulations. Peter has presented his work at multiple international conferences and recently publisheded his work in the Simulation Modelling Practice and Theory Journal.

--- a/_events/seminar-2018-06-19.md
+++ b/_events/seminar-2018-06-19.md
@@ -1,0 +1,35 @@
+---
+category: seminar
+date: 2018-06-19
+published: true
+
+from: "12:00"
+to: "13:00"
+location: "COM-G12-Main Lewin"
+speaker: "Dr Patricio Ortiz"
+institute: "University of Sheffield"
+title: "Tackling the learning curve of scientific programming"
+
+image: "/assets/seminar_files/img/2018_06_19_curve.jpg"
+slides_url: "/assets/seminar_files/slides/2018_06_19_curve_talk.pdf"
+
+---
+**Abstract**: Programming is part of the curriculum of students of computer science, and it will be complemented with other related subjects to make them knowledgeable on the subject. The situation of a science or engineering student is the opposite; typically they have one course to learn one language, and that language is usually not the one they will first face in real-life situations. This situation has occurred for decades, and it is likely not going to change, but there is a real need to better prepare science and engineering students to face the very steep learning curve of having to start programming as part of an ongoing project or their thesis.
+
+Universities like ours offer excellent facilities like the HPCs supplied by CICS, yet the reality is that many students and young researchers may have never used a Unix based system, let alone a parallel system.
+
+The book I wrote, "first steps in scientific programmings" aims at facilitating the passage through the learning curve by providing tips based on years of experience and my interaction with students and brilliant young researchers who did not have the opportunity to learn anywhere else the challenges which programming in a scientific environment involve.
+
+I will briefly describe the points which I think are more important to emphasise, points which I've confirmed as important by interacting with other experienced researchers at the U. of Sheffield, who are trying to provide support for the people starting in this field.
+
+Link for the book:
+[https://sites.google.com/view/fsscientificprogramming/home](https://sites.google.com/view/fsscientificprogramming/home)
+
+A supportive link:
+[https://sites.google.com/a/sheffield.ac.uk/rcg/my-blog/research-computing-notes/firststepsinscientificprogramming](https://sites.google.com/a/sheffield.ac.uk/rcg/my-blog/research-computing-notes/firststepsinscientificprogramming)
+
+**Bio**: Patricio Ortiz holds a PhD. in astronomy from the University of Toronto, Canada. He has a keen interest in programming as a mean to create tools to help his research when no tools were available. He has taught at the graduate and undergraduate levels in subjects about astronomy, instrumentation, and applied programming. Throughout his career, Patricio has interacted with students at any level as well as post-graduates, helping him identify the most critical subjects needed by young scientists in the physical sciences and usually not covered by current literature. He has worked on projects involving automated super-nova detection systems; detection of fast moving solar system bodies, including Near-Earth objects and he was involved in the Gaia project (European Space Agency) for nearly ten years. Patricio also developed an ontology system used since its conception by the astronomical community to identify equivalent quantities. He also worked on an Earth Observation project, which gave him the opportunity to work extensively with high-performance computers, leading to his development of an automated task submission system which significantly decreases the execution time of data reduction of extended missions.
+
+
+Patricio now works as a Research Software Engineer at the Department of Automatic Control and Systems Engineering at the University of Sheffield. He uses C, Fortran, Python, Java and Perl as his main toolkits, and as a pragmatic person, he uses the language which suits a problem best. Amongst his interests are: scientific data visualisation as a discovery tool, photography and (human) languages.
+

--- a/_events/seminar-2018-06-27.md
+++ b/_events/seminar-2018-06-27.md
@@ -1,0 +1,18 @@
+---
+category: seminar
+date: 2018-06-27
+published: true
+
+from: "15:30"
+to: "16:30"
+location: "Hicks building, Lecture Theatre 7"
+speaker: "Jos Martin"
+institute: "Mathworks"
+title: "Software engineering in practise"
+
+image: 
+slides_url:
+---
+**Abstract**: Jos will discuss how MathWorks develop and extend MATLAB and its associated tools from an engineering perspective. Focusing on the opportunities – and challenges – in ensuring MATLAB continues to be the tool of choice in the world of multicore CPUs, in grids and clouds, on mobile platforms, and on GPUs. He discusses the processes involved in developing and testing MATLAB to drive usability features, development environment enhancements, and overall reliability.
+
+**Bio**: Jos Martin is the senior engineering manager for parallel computing products at MathWorks. He has responsibility for all parts of Parallel Computing Toolbox, including the use of GPU and big data types in other areas. In addition, he is also responsible for MATLAB Drive, MATLAB Connector, and products that help link the desktop to the cloud. Before moving to a development role within MathWorks, he worked as a consultant in the U.K., writing large-scale MATLAB applications, particularly in the finance and automotive sectors. Prior to joining MathWorks in 2000, he held a Royal Society Post-Doctoral Fellowship at the University of Otago, New Zealand. His area of research was Experimental Bose-Einstein Condensation (BEC), a branch of low-temperature atomic physics.

--- a/_events/seminar-2018-09-12.md
+++ b/_events/seminar-2018-09-12.md
@@ -1,0 +1,18 @@
+---
+category: seminar
+date: 2018-09-12
+published: true
+
+from: "15:30"
+to: "16:30"
+location: "Hicks building, Lecture Theatre 7"
+speaker: "Rob Baxter" 
+institute: "EPCC"
+title: "Don’t Panic! Demystifying Big Data, Data Science and all that."
+image:
+slides_url:
+
+---
+**Abstract**: The world’s digital data are still doubling in number every year or so, and research is a big culprit. Whether you measure it by volume, velocity or variety, research data is getting Big. All is not lost, though. It is challenging, and it does take a slightly different approach, but dealing with oodles of research data is not as terrifying as it seems. In this talk I aim to give researchers some practical ideas on working with “big” research data, illustrated with examples of how we manage stuff like this at EPCC. 
+
+**Bio**: [https://www.epcc.ed.ac.uk/about/staff/dr-rob-baxter](https://www.epcc.ed.ac.uk/about/staff/dr-rob-baxter)

--- a/_events/seminar-2018-10-30.md
+++ b/_events/seminar-2018-10-30.md
@@ -1,0 +1,19 @@
+---
+category: seminar
+date: 2018-10-30
+published: true
+
+from: "12:00"
+to: "13:00"
+location: "COM-G12-Main Lewin"
+speaker: "Andrew Turner"
+institute: "EPCC"
+title: "Open source UK HPC benchmarking"
+image: "/assets/seminar_files/img/2018_10_30_epcc.jpg"
+slides_url: "https://aturner-epcc.github.io/presentations/Sheff_Oct2018/"
+---
+**Abstract**: The recent investments in national HPC services in the UK (for example the national Tier2 HPC services and DiRAC 2.5x) and the offerings from public cloud providers have led to a wider range of advanced computing architectures available to UK-based researchers. We have undertaken a comparative benchmarking exercise across these different services to help improve our understanding of the performance characteristics of these platforms and help researchers choose the best services for different stages of their research workflows. In this seminar we will present results comparing the performance of different architectures for traditional HPC applications (e.g. CFD, periodic electronic structure) and synthetic benchmarks (for assessing I/O and interconnect performance limits). We will also describe how we have used an open research model where all the results and analysis methodologies are publicly available at all times. We will comment on the ease (or not) of compiling applications on the different platforms in a performant way, assess the strengths and weakness of architectures for different workloads, and demonstrate the benefits of working in an open way
+
+Benchmarking repository: [https://github.com/hpc-uk/archer-benchmarks](https://github.com/hpc-uk/archer-benchmarks)
+
+**Bio**: Andy works for EPCC at the University of Edinburgh and has a particular focus on helping users get the best from the national HPC services around the UK. Much of his recent work has focussed on achieving this through an open benchmarking exercise comparing performance across different HPC systems and different applications and by developing HPC Carpentry training to provide researchers with the tools they need to use advanced computing in their research.

--- a/_events/seminar-2018-11-27.md
+++ b/_events/seminar-2018-11-27.md
@@ -1,0 +1,24 @@
+---
+category: seminar
+date: 2018-11-27
+published: false
+
+from: "12:00"
+to: "13:00"
+location: "COM-G12-Main Lewin"
+speaker: "Luke Mason"
+institute: "Application Performance Engineering Group Leader at Hartree Center"
+title: "Software Outlook"
+image: 
+slides_url:
+---
+**Abstract**: Software Outlook is a project funded by the EPSRC as part of the Computational Science Centre for Research Communities. It aims to support the UK’s Collaborative Computational Projects (CCPs) and High-End Computing (HEC) Consortia in the development and optimisation of their world-leading software. These activities include
+
+* Evaluations of new programming languages, libraries and frameworks
+* Investigations into timely and cost-effective exploitation of current and near-future systems
+* Demonstrations into how specific software technologies can be applied to existing applications
+
+The challenges faced by CCP’s and HEC consortia in modernising their codes are fed directly into Software Outlook’s remit. During this talk, we will discuss these challenges and the subsequent work being done by Software Outlook.
+
+
+**Bio**: Luke leads the High Performance Software Engineering group at the Hartree Centre. The group specialises in code scalability and performance on HPC (high performance computing) systems as well as porting and optimisation for emerging and novel architectures. He is experienced in working alongside both industrial and academic scientists to produce accurate and efficient code across a range of disciplines and architectures. His group is involved in development for the Met Office and the EPSRC funded “Big Hypotheses” project, to name just a few of its current activities.

--- a/_events/seminar-2019-01-29.md
+++ b/_events/seminar-2019-01-29.md
@@ -1,0 +1,25 @@
+---
+category: seminar
+date: 2019-01-29
+published: true
+
+from: "12:00"
+to: "13:00"
+location: "COM-G12-Main Lewin"
+speaker: "Dr Spiridon Siouris"
+institute: "University of Sheffield"
+title: "Taking up development of existing research codes. A discussion on common issues and effective ways of dealing with them"
+
+image:
+slides_url:
+---
+
+**Abstract**: Research codes in Engineering are written with the aim of generating results as quick as possible so that interesting physical phenomena can be analysed. However, time constraints, lack of formal training in Computer Science/Software development, and pressure for results leads to software that can be problematic. In this talk we will discuss about:
+* The issues faced with research software and the need for maintainable and reliable code
+* The steps taken for quickly getting familiarised and productive in code development
+* The tools used, such as for documentation, debugging, profiling 
+* Holistic approach on code optimisation
+* Good programming practices, along with references for further reading
+The aspects of software development discussed here will be helpful to researchers joining projects that require further development of existing software, and also researchers that are tasked to create new software.
+
+**Bio**: Dr. Spiridon Siouris is a Research Fellow in the Low Carbon Combustion Group in Mechanical Engineering at The University of Sheffield. His research is focused on modeling chemically reacting flows in gas turbine fuel and lubrication systems using CFD and lower order modelling codes. Currently he is working on further developing a CFD code in which wall boundaries can deform according to deposition growth layers due to thermal oxidative degradation in jet fuels (FINCAP project with Rolls Royce). For over a decade he has been involved in numerous software projects for aerospace applications, and has worked alongside students, PhD researchers, and professional engineers developing modeling software. He has been exposed to a wide range in quality of coding, and his enthusiasm for computers, programming and engineering, drive him to educate people towards developing high quality software.

--- a/_includes/event.html
+++ b/_includes/event.html
@@ -1,0 +1,1 @@
+{% include {{event.category}}_individual.html event=event %}

--- a/_includes/events_list.html
+++ b/_includes/events_list.html
@@ -1,0 +1,8 @@
+
+{% assign events = (site.events | sort: 'date' | reverse) %}
+{% if events and events.size > 0 %}
+{% for event in events %}
+  {% include event.html event=event %}
+{% endfor %}
+
+{% endif %}

--- a/_includes/seminar_individual.html
+++ b/_includes/seminar_individual.html
@@ -1,0 +1,31 @@
+<section id="seminar-{{include.event.date}}" class="seminar-section">
+
+{% if include.event %}
+
+<h3><a href="{{include.event.url}}">{{ include.event.date | date: "%A %e, %Y" }} &mdash; {{include.event.from}}-{{include.event.to}}, {{include.event.location}}</a></h3>
+<p>
+    <strong>{{include.event.speaker}}{%if include.event.institute%}, {{include.event.institute}}{%endif%}</strong>
+</p>
+<p>
+<strong>Talk</strong>: <em>"{{include.event.title}}"</em>
+</p>
+
+{{include.event.content}}
+
+{% if include.event.slides_url %}
+<p>
+    <a href="{{include.event.slides_url}}">SLIDES</a>
+</p>
+{% endif %}
+
+{% if include.event.image %}
+<figure class="text-center">
+<img src="{{include.event.image}}" class="img-fluid w-50" />
+</figure>
+{% endif %}
+
+<hr />
+
+{% endif %}
+
+</section>

--- a/_layouts/event.html
+++ b/_layouts/event.html
@@ -1,0 +1,14 @@
+---
+layout: default
+---
+
+<section class="section offset-header flex-fill" >
+
+    <div class="container">
+        <div class="row">
+            <div class="col-12" markdown=1>
+                {% include {{page.category}}_individual.html event=page %}
+            </div>
+        </div>
+    </div>
+</section>

--- a/pages/community/seminars.md
+++ b/pages/community/seminars.md
@@ -14,211 +14,49 @@ This page provides a list of upcoming and previous seminars held by RSE@Sheffiel
 
 If you would like to recommend a speaker or would like to give a talk then please [contact us](/contact). We have a budget to support inviting speakers.
 
-# Upcoming Seminars #
-<br/>
-
-### <span style="background-color: #FFFF00">January 29, 2019</span> &mdash; 12:00-13:00, COM-G12-Main Lewin
-**Dr Spiridon Siouris, University of Sheffield**
-
-**Talk:** *"Taking up development of existing research codes. A discussion on common issues and effective ways of dealing with them"*
-
-**Abstract:** Research codes in Engineering are written with the aim of generating results as quick as possible so that interesting physical phenomena can be analysed. However, time constraints, lack of formal training in Computer Science/Software development, and pressure for results leads to software that can be problematic. In this talk we will discuss about:
-
-* The issues faced with research software and the need for maintainable and reliable code
-* The steps taken for quickly getting familiarised and productive in code development
-* The tools used, such as for documentation, debugging, profiling 
-* Holistic approach on code optimisation
-* Good programming practices, along with references for further reading
-
-The aspects of software development discussed here will be helpful to researchers joining projects that require further development of existing software, and also researchers that are tasked to create new software.
-
-**Bio:** Dr. Spiridon Siouris is a Research Fellow in the Low Carbon Combustion Group in Mechanical Engineering at The University of Sheffield. His research is focused on modeling chemically reacting flows in gas turbine fuel and lubrication systems using CFD and lower order modelling codes. Currently he is working on further developing a CFD code in which wall boundaries can deform according to deposition growth layers due to thermal oxidative degradation in jet fuels (FINCAP project with Rolls Royce). For over a decade he has been involved in numerous software projects for aerospace applications, and has worked alongside students, PhD researchers, and professional engineers developing modeling software. He has been exposed to a wide range in quality of coding, and his enthusiasm for computers, programming and engineering, drive him to educate people towards developing high quality software.
-
-<br/><hr/><br/>
-
-<!--
-### <span style="background-color: #FFFF00">November 27, 2018</span> &mdash; 12:00-13:00, COM-G12-Main Lewin
-**Luke Mason, Application Performance Engineering Group Leader at Hartree Center**
-
-**Talk:** *"Software Outlook"*
-
-**Abstract:** Software Outlook is a project funded by the EPSRC as part of the Computational Science Centre for Research Communities. It aims to support the UK’s Collaborative Computational Projects (CCPs) and High-End Computing (HEC) Consortia in the development and optimisation of their world-leading software. These activities include
-
-* Evaluations of new programming languages, libraries and frameworks
-* Investigations into timely and cost-effective exploitation of current and near-future systems
-* Demonstrations into how specific software technologies can be applied to existing applications
-
-The challenges faced by CCP’s and HEC consortia in modernising their codes are fed directly into Software Outlook’s remit. During this talk, we will discuss these challenges and the subsequent work being done by Software Outlook.
-
-**Bio:** Luke leads the High Performance Software Engineering group at the Hartree Centre. The group specialises in code scalability and performance on HPC (high performance computing) systems as well as porting and optimisation for emerging and novel architectures. He is experienced in working alongside both industrial and academic scientists to produce accurate and efficient code across a range of disciplines and architectures. His group is involved in development for the Met Office and the EPSRC funded “Big Hypotheses” project, to name just a few of its current activities.
--->
-
-# Previous Seminars #
-<br/>
-
-### <span style="background-color: #FFFF00">October 30, 2018</span> &mdash; 12:00-13:00, COM-G12-Main Lewin
-**Andrew Turner (EPCC)**
-
-**Talk:** *"Open source UK HPC benchmarking"*
-
-**Abstract:** The recent investments in national HPC services in the UK (for example the national Tier2 HPC services and DiRAC 2.5x) and the offerings from public cloud providers have led to a wider range of advanced computing architectures available to UK-based researchers. We have undertaken a comparative benchmarking exercise across these different services to help improve our understanding of the performance characteristics of these platforms and help researchers choose the best services for different stages of their research workflows. In this seminar we will present results comparing the performance of different architectures for traditional HPC applications (e.g. CFD, periodic electronic structure) and synthetic benchmarks (for assessing I/O and interconnect performance limits). We will also describe how we have used an open research model where all the results and analysis methodologies are publicly available at all times. We will comment on the ease (or not) of compiling applications on the different platforms in a performant way, assess the strengths and weakness of architectures for different workloads, and demonstrate the benefits of working in an open way
-
-Benchmarking repository: [https://github.com/hpc-uk/archer-benchmarks](https://github.com/hpc-uk/archer-benchmarks)
-
-**Bio:** Andy works for EPCC at the University of Edinburgh and has a particular focus on helping users get the best from the national HPC services around the UK. Much of his recent work has focussed on achieving this through an open benchmarking exercise comparing performance across different HPC systems and different applications and by developing HPC Carpentry training to provide researchers with the tools they need to use advanced computing in their research.
-
-
-<center><img src="/assets/seminar_files/img/2018_10_30_epcc.jpg" alt=""  style="max-width: 500px"></center>
-<strong><a href="https://aturner-epcc.github.io/presentations/Sheff_Oct2018/">SLIDES</a></strong>
-
-
-
-<br/><hr/><br/>
-
-### <span style="background-color: #FFFF00">September 12, 2018</span> &mdash; 15:30-16:30, Hicks building, Lecture Theatre 7
-
-**Rob Baxter (EPCC)**
-
-**Talk:** *"Don’t Panic! Demystifying Big Data, Data Science and all that."*
-
-**Abstract:** The world’s digital data are still doubling in number every year or so, and research is a big culprit. Whether you measure it by volume, velocity or variety, research data is getting Big. All is not lost, though. It is challenging, and it does take a slightly different approach, but dealing with oodles of research data is not as terrifying as it seems. In this talk I aim to give researchers some practical ideas on working with “big” research data, illustrated with examples of how we manage stuff like this at EPCC. 
-
-**Bio:** [https://www.epcc.ed.ac.uk/about/staff/dr-rob-baxter](https://www.epcc.ed.ac.uk/about/staff/dr-rob-baxter)
-
-<br/><hr/><br/>
-
-### <span style="background-color: #FFFF00">June 27, 2018</span> &mdash; 15:30-16:30, Hicks building, Lecture Theatre 7
-
-**Jos Martin (Mathworks)**
-
-**Talk:** *"Software engineering in practise"*
-
-**Abstract:** Jos will discuss how MathWorks develop and extend MATLAB and its associated tools from an engineering perspective. Focusing on the opportunities – and challenges – in ensuring MATLAB continues to be the tool of choice in the world of multicore CPUs, in grids and clouds, on mobile platforms, and on GPUs. He discusses the processes involved in developing and testing MATLAB to drive usability features, development environment enhancements, and overall reliability.
-
-**Bio:** Jos Martin is the senior engineering manager for parallel computing products at MathWorks. He has responsibility for all parts of Parallel Computing Toolbox, including the use of GPU and big data types in other areas. In addition, he is also responsible for MATLAB Drive, MATLAB Connector, and products that help link the desktop to the cloud. Before moving to a development role within MathWorks, he worked as a consultant in the U.K., writing large-scale MATLAB applications, particularly in the finance and automotive sectors. Prior to joining MathWorks in 2000, he held a Royal Society Post-Doctoral Fellowship at the University of Otago, New Zealand. His area of research was Experimental Bose-Einstein Condensation (BEC), a branch of low-temperature atomic physics.
-
-<br/><hr/><br/>
-
-### <span style="background-color: #FFFF00">June 19, 2018</span> &mdash; 12:00-13:00, COM-G12-Main Lewin ###
-
-**Dr Patricio Ortiz, University of Sheffield**
-
-**Talk:** *"Tackling the learning curve of scientific programming"*
-
-**Abstract:** Programming is part of the curriculum of students of computer science, and it will be complemented with other related subjects to make them knowledgeable on the subject. The situation of a science or engineering student is the opposite; typically they have one course to learn one language, and that language is usually not the one they will first face in real-life situations. This situation has occurred for decades, and it is likely not going to change, but there is a real need to better prepare science and engineering students to face the very steep learning curve of having to start programming as part of an ongoing project or their thesis.
-Universities like ours offer excellent facilities like the HPCs supplied by CICS, yet the reality is that many students and young researchers may have never used a Unix based system, let alone a parallel system.
-
-The book I wrote, "first steps in scientific programmings" aims at facilitating the passage through the learning curve by providing tips based on years of experience and my interaction with students and brilliant young researchers who did not have the opportunity to learn anywhere else the challenges which programming in a scientific environment involve.
-
-I will briefly describe the points which I think are more important to emphasise, points which I've confirmed as important by interacting with other experienced researchers at the U. of Sheffield, who are trying to provide support for the people starting in this field.
-
-Link for the book:
-[https://sites.google.com/view/fsscientificprogramming/home](https://sites.google.com/view/fsscientificprogramming/home)
-
-A supportive link:
-
-[https://sites.google.com/a/sheffield.ac.uk/rcg/my-blog/research-computing-notes/firststepsinscientificprogramming](https://sites.google.com/a/sheffield.ac.uk/rcg/my-blog/research-computing-notes/firststepsinscientificprogramming)
-
-**Bio:** Patricio Ortiz holds a PhD. in astronomy from the University of Toronto, Canada. He has a keen interest in programming as a mean to create tools to help his research when no tools were available. He has taught at the graduate and undergraduate levels in subjects about astronomy, instrumentation, and applied programming. Throughout his career, Patricio has interacted with students at any level as well as post-graduates, helping him identify the most critical subjects needed by young scientists in the physical sciences and usually not covered by current literature. He has worked on projects involving automated super-nova detection systems; detection of fast moving solar system bodies, including Near-Earth objects and he was involved in the Gaia project (European Space Agency) for nearly ten years. Patricio also developed an ontology system used since its conception by the astronomical community to identify equivalent quantities. He also worked on an Earth Observation project, which gave him the opportunity to work extensively with high-performance computers, leading to his development of an automated task submission system which significantly decreases the execution time of data reduction of extended missions.
-
-
-Patricio now works as a Research Software Engineer at the Department of Automatic Control and Systems Engineering at the University of Sheffield. He uses C, Fortran, Python, Java and Perl as his main toolkits, and as a pragmatic person, he uses the language which suits a problem best. Amongst his interests are: scientific data visualisation as a discovery tool, photography and (human) languages.
-
-<center><img src="/assets/seminar_files/img/2018_06_19_curve.jpg" alt=""  style="max-width: 500px"></center>
-<strong><a href="/assets/seminar_files/slides/2018_06_19_curve_talk.pdf">SLIDES</a></strong>
-
-<br/><hr/><br/>
-
-### <span style="background-color: #FFFF00">April 30, 2018</span> &mdash; 15:00-16:00, Broad Lane Lecture Theater 11 (BROAD-LT11) ###
-
-**Peter Heywood, University of Sheffield**
-
-**Talk:** *"Accelerating Road Network Simulations using GPUs"*
-
-**Abstract:** Road network Simulations are a vital tool used in the planning and management of transport network infrastructure. Large-scale simulations are computationally expensive tasks, taking many-hours for a single simulation to complete using multi-core CPU architectures, hindering the use of large-scale simulations.
-
-Using Graphics Processing Units (GPUs) we demonstrate that both Macroscopic (top-down) simulations and Microscopic (bottom-up) simulations can be considerably accelerated using many-core architectures and novel fine-grained data-parallel algorithms.
-
-A multi-GPU version of the SATURN macroscopic road network simulation package has been developed, demonstrating assignment performance improvements of over 11x compared to a multi-socket CPU. A FLAME GPU based microscopic simulation demonstrates performance improvements of up to 65x using a single GPU compared to the commercial multi-core microsimulation tool Aimsun.
-
-**Bio:** Peter Heywood is a Research Software Engineer and PhD candidate at the University of Sheffield. His research is focussed on using Graphics Processing Units (GPUs) to improve the performance of complex systems simulations; including transport network simulation and biological cellular simulations. Peter has presented his work at multiple international conferences and recently published his work in the Simulation Modelling Practice and Theory Journal.
-
-<center><img src="/assets/seminar_files/img/2018_04_30_roadNetwork.jpg" alt=""  style="max-width: 500px"></center>
-
-<br/><hr/><br/>
-
-### <span style="background-color: #FFFF00">April 16, 2018</span> &mdash; 15:30-16:30, Hicks building, Lecture Theatre 6
-
-**David Hubber, Researcher at Ludwig-Maximilians-Universität Munich**
-
-**Talk:** *"Structuring code efficiently"*
-
-**Abstract:** David will discuss how to structure code efficiently. He will also discuss code module design, decoupling strategies and test-driven development. 
-
-**Bio:** David Hubber is an astrophysicist by training that has worked extensively on writing software such as GANDALF and SEREN to simulate star forming regions. He has been a researcher at the university of Cardiff, the university of Sheffield, and is currently a Postdoc researcher Ludwig-Maximilians-Universitat Munich.
-
-<br/><hr/><br/>
-
-### <span style="background-color: #FFFF00">November 28, 2017</span> &mdash; 11:00-12:00, Lecture Theatre G02, Firth Court ###
-
-**Dr Stephen McGough, Newcastle University**
-
-**Talk:** *"PARALLEM: massively Parallel Landscape Evolution Modelling"*
-
-**Abstract:** Landscape Evolution Modelling (LEM) is used to predict how landscapes evolve over the millennia due to weathering and erosion. LEM's normally operate on a regular grid of cells each representing the height of a point within a landscape. The process can be broken up into the following stages applied to each cell: determination of the flow direction of water out of that cell, summation of the volume of water flowing through the cell and computation of the erosion / deposition in the cell. This process is repeated at regular intervals - either an annual time-step (due to computation complexity) or once for each major storm-event - for periods of around one million years. 
-
-Within each year/rainstorm there is great potential for speedup when executing on a GPGPU - flow direction for most cells can be performed independently, flow accumulation can easily be performed in parallel. However, due to certain 'real world' landscape features this potential can easily be lost. Landscape features such as plateaus - where all cells in a region have the same height - or sinks - (sets of) cells which have no lower neighbour, meaning water cannot escape - prevent optimal speedup being achieved. Likewise, computing the volume of water passing through a cell is inherently sequential - the sum of water through a cell at the end of a river depends on knowing the volume of water passing through all points upstream.
-
-CUDA algorithms have been developed for computing the LEM processes: Flow direction can be computed independently for each cell; A parallel breadth-first algorithm can be used for routing water over a plateau to an outlet cell; A parallel technique for 'filling' sinks (making them into lakes) which performs much of its work through parallel pointer jumping is used. Flow accumulation can be performed using a developed 'correct' algorithm where each cell which has no incorrect flows entering it can be computed and marked correct. The process of erosion / deposition can then be performed in a similar manner to flow accumulation with the eroded material being passed around. 
-
-In this talk we will present parallel techniques for overcoming these problems, demonstrating between two and three orders of magnitude speedup over the best-in- class LEM software for landscapes between 0.1 and 56 million cells - far larger than the traditional 5 thousand cell simulations which have previously been performed. This has led to a need for a re-evaluation of the models used within the LEM community. Errors in LEM simulation results, which have been used over the last 30+ years, have been attributed to the very small simulation sizes. However, with our 46+ million cell simulations - a realistic scale - we are now able to determine that these errors are not due to scale but rather due to the equations themselves.
-
-We will present our approach moving forwards to overcome these limitations and present initial results of this work.
-
-**Bio:** Dr Stephen McGough is a Senior Lecturer in the School of Computing at Newcastle University, UK. He obtained his PhD in the area of Parallel simulation and has worked for many years in the areas of parallel computing and simulation. Holding posts at Imperial College London, UCL, Newcastle University and Durham University. This has led to over fifty publications in the area of parallel computing including receiving the NVIDIA best paper award at HiPC 2012. His research focuses on the use of novel computing technologies, such as GPGPU, to solve real-world challenges.
-
-<center><img src="/assets/seminar_files/img/2017_11_28_parallem.jpg" alt=""  style="max-width: 500px"></center>
-<strong><a href="/assets/seminar_files/slides/2017_11_28_gpu_parallem_talk.pdf">SLIDES</a></strong>
-
-<br/><hr/><br/>
-
-### <span style="background-color: #FFFF00">September 09, 2017</span> &mdash; 13:00-14:00, Workroom 3 (205), The Diamond ###
-
-**Dr Thomas Nowotny, University of Sussex**
-
-**Talk:** *"Opportunities and challenges for spiking neural networks on GPUs"*
-
-**Abstract:** In the past 6 years, we have developed the GeNN (GPU enhanced neuronal networks) framework for GPU accelerated spiking neuronal network simulations. In essence, GeNN is based on a simple design of code generation that allows a large extent of flexibility for computational models while at the same time taking care of some of the GPU specific optimisation work in the background. In this talk I will present the main features of GeNN, its design principles and show benchmarks. I will then discuss limitations, both specific to GeNN and to numerical simulation work on GPUs more generally and present some further work, including the SpineML-GeNN and Brian2GeNN interfaces. GeNN is developed within the Green Brain [http://greenbrain.group.shef.ac.uk/](http://greenbrain.group.shef.ac.uk/) and Brains on Board [http://brainsonboard.co.uk/](http://brainsonboard.co.uk/) projects and is available under GPL v2 at Github [http://genn-team.github.io/genn/](http://genn-team.github.io/genn/).
-
-**Bio:** Thomas Nowotny received his PhD in theoretical physics in 2001 from the University of Leipzig and worked for five years at the University of California, San Diego. In 2007 he joined the University of Sussex, where he is now a Professor of Informatics and the Director for Research and Knowledge Exchange at the School of Engineering and Informatics. His research interests include olfaction in animals and machines, GPU accelerated scientific computing, hybrid brain-computer systems and bio-inspired machine learning.
-
-<center><img src="/assets/seminar_files/img/2017_09_27_thomas_nowotny.jpg" alt=""  style="max-width: 500px"></center>
-<strong><a href="https://sussex.app.box.com/s/8i7dby89e6fj2t8lw447y68dkrsc1oo5">SLIDES</a></strong>
-
-<br/><hr/><br/>
-
-### <span style="background-color: #FFFF00">August 08, 2017</span> &mdash; 13:00-14:00, Workroom 3 (205), The Diamond ###
-
-**Twin Karmakharm, Research Software Engineer, University of Sheffield**
-
-**Talk:** *"Containers for High Performance Computing"*
-
-**Abstract:** Containerization is a lightweight virtualisation technology where users can package workflows, software, libraries and data for running on various machines with minimal loss of performance. The technology can be used a way for scientists to deploy custom software on the HPC cluster and easily share reproducible software along with their data. The talk explores the concept of containers and existing container technologies suitable for the HPC. Particular focus is given for Singularity which has recently been introduced on the new Sheffield Advance Research Computer (ShARC) cluster.
-
-<center><img src="/assets/seminar_files/img/2017_08_29_gpu_containers.jpg" alt=""  style="max-width: 500px"></center>
-
-<br/><hr/><br/>
-
-### <span style="background-color: #FFFF00">May 30, 2017</span> &mdash; 13:00-14:00, Workroom 2 (G05), The Diamond ###
-
-**Ania Brown, Research Software Engineer, Oxford e-Research Centre**
-
-**Talk:** *"Towards achieving GPU-native adaptive mesh refinement"*
-
-**Abstract:** Modern simulations model increasingly complex multiscale systems, and the need to capture details at multiple length scales can lead to large memory requirements. Adaptive mesh refinement (AMR) is a method for reducing memory cost by varying the accuracy in each region to match the physical characteristics of the simulation, at the cost of increased data structure complexity. This complexity is a particular problem on the GPU architecture, which is most naturally suited to regular data sets. I will describe some of the optimisation and software challenges that need to be considered when implementing AMR on GPUs, based on my experience working on a GPU-native framework for stencil calculations on a tree-based adaptively refined mesh as part of my Master degree. Topics covered will include achieving coalesced access with the AMR data structure, memory defragmentation after grid changes and load balancing using space-filling curves.
-
-**Bio:** Ania is a research software engineer at the Oxford e-Research Centre. Her research interests are a combination of performance optimisation for large scale scientific simulation and software development methodology to improve the quality of such codes. She received her Master degree from the Tokyo Institute of Technology in 2015.
-
-<center><img src="/assets/seminar_files/img/2017_05_30_gpu_amr.jpg" alt=""  style="max-width: 400px"></center>
-<strong><a href="/assets/seminar_files/slides/2017_05_30_gpu_amr_talk.pdf">SLIDES</a></strong>
+{% assign seminars = (site.events | where: 'category', 'seminar' | sort: 'date' | reverse) %}
+{% if seminars and seminars.size > 0 %}
+
+## Seminars
+
+{% for seminar in seminars %}
+    {% assign object = seminar %}
+  {% include seminar_individual.html event=seminar %}
+{% endfor %}
+
+{% endif %}
+
+<script type="text/javascript">
+    // Get the current date 
+    var now = new Date();
+    // Select all seminar elements
+    var elements = document.getElementsByClassName("seminar-section");
+    // Select the seminars heading
+    var seminars_heading = document.getElementById("seminars");
+    // Initialise a variable to store the last event which is in the future
+    last_upcoming_element = null;
+    // Iterate elements
+    for (var i = 0; i < elements.length; i++) {
+        element = elements[i]
+        // Construct a date object based on the date of the event
+        split_id = element.id.split("-")
+        seminar_date = new Date(split_id[1], split_id[2] - 1, split_id[3]);
+        // If the event is in the future, store it.
+        if(seminar_date > now){
+            last_upcoming_element = element
+        }
+    }
+    // Modify / insert headings as appropriate, based on if any future seminars exist
+    if(last_upcoming_element != null){
+        // Modify existing heading
+        seminars_heading.textContent = "Upcoming Seminars";
+        // Inert a new heading after the last future event
+        new_heading = document.createElement(seminars_heading.nodeName);
+        new_heading.textContent = "Previous Seminars";
+        last_upcoming_element.insertAdjacentElement('afterend', new_heading);
+    } else {
+        // Modify existing heading
+        seminars_heading.textContent = "Previous Seminars";
+    }
+</script>
 

--- a/pages/events.md
+++ b/pages/events.md
@@ -1,0 +1,7 @@
+---
+title: Events
+layout: page
+permalink: /events/
+---
+
+{% include events_list.html %}

--- a/pages/training/COM605.md
+++ b/pages/training/COM605.md
@@ -1,5 +1,5 @@
 ---
-title: COM605: Good Practice for Research Software
+title: "COM605: Good Practice for Research Software"
 slug: COM605
 layout: page
 permalink: /training/COM605/


### PR DESCRIPTION
Implements the seminars as members of an events collection. 

The events collection can then also include non-seminar events, although an include `<category>-individual.html` file would also be required. It is then simple to filter for each page and render using that pattern.

This is not set in stone either. 