### PR TITLE
Fix bug with seminar page javascript

### DIFF
--- a/_includes/seminar_individual.html
+++ b/_includes/seminar_individual.html
@@ -1,4 +1,4 @@
-<section id="seminar-{{include.event.date}}" class="seminar-section">
+<section id="seminar-{{ include.event.date | date: "%Y-%m-%d" }}" class="seminar-section">
 
 {% if include.event %}
 


### PR DESCRIPTION
The format of the date stored in the ID included the time on the actual github website.
Modified the template to explicitly format as YYYY-MM-DD, so the JS works.